### PR TITLE
Disable linus-riscv64 on alpine-edge temporary.

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -38,7 +38,7 @@ jobs:
             platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
             extra_packages: hugo-bash-completion
           - tag: alpine-edge
-            platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64
+            platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
             extra_packages: hugo-bash-completion
           - tag: alpine-3.15.0
             platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le


### PR DESCRIPTION
This should be reverted later.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
